### PR TITLE
Enhance theme toggle and scroll navigation

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -29,7 +29,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const observerOptions = {
         root: null, // relative to document viewport
         rootMargin: '0px',
-        threshold: 0.6 // 60% of section visible
+        threshold: 0.25 // Changed from 0.6 to 0.25 (25% of section visible)
     };
 
     const observer = new IntersectionObserver((entries, obs) => {
@@ -67,8 +67,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const themeIcon = document.getElementById('theme-icon'); // Get the icon span
     const body = document.body;
 
-    const moonIcon = '🌙'; // Unicode moon character
-    const sunIcon = '☀️'; // Unicode sun character
+    const moonIcon = '🌙\uFE0E'; // Unicode moon character with text presentation selector
+    const sunIcon = '☀️\uFE0E'; // Unicode sun character with text presentation selector
 
     // Function to apply the saved theme or default to dark
     function applyTheme(theme) {

--- a/static/style.css
+++ b/static/style.css
@@ -155,16 +155,22 @@ body.light-theme header nav ul li a {
 header nav ul li a:hover,
 header nav ul li a.active { /* For active page or hover */
     color: var(--nav-link-hover-dark);
+    font-weight: bold;
 }
 
 body.light-theme header nav ul li a:hover,
 body.light-theme header nav ul li a.active {
     color: var(--nav-link-hover-light);
+    font-weight: bold;
 }
 
 /* Main Content Sections */
 main {
     padding-top: 80px; /* Adjust based on header height */
+}
+
+section[id] { /* Apply to sections that can be targeted by ID */
+    scroll-margin-top: 80px; /* Offset for the fixed header height */
 }
 
 section {
@@ -522,6 +528,8 @@ body.light-theme .flash.error {
 #theme-icon {
     display: inline-block;
     transition: transform 0.3s ease-in-out, opacity 0.2s ease;
+    filter: grayscale(100%);
+    opacity: 1; /* Ensure full opacity if grayscale affects it */
 }
 
 /* Initial state for icons (moon visible, sun hidden by JS initially or vice-versa) */
@@ -529,5 +537,33 @@ body.light-theme .flash.error {
 
 /* Animation for icon transition */
 .theme-icon-spin {
-    transform: rotate(180deg);
+    transform: rotate(45deg);
+}
+
+/* Remove border and background from theme toggle icon */
+.theme-button-icon {
+    padding: 8px 12px;
+    font-size: 1.2em;
+    line-height: 1;
+    border: none !important;
+    background: none;
+    box-shadow: none;
+}
+
+.theme-button-icon:hover,
+.theme-button-icon:focus {
+    border: none !important;
+    background: none;
+    outline: none;
+    box-shadow: none;
+}
+
+/* Prevent hover background color just for the theme toggle button */
+.theme-button-icon:hover,
+body.light-theme .theme-button-icon:hover {
+    background-color: transparent !important;
+    color: inherit !important;
+    border: none !important;
+    outline: none !important;
+    box-shadow: none !important;
 }


### PR DESCRIPTION
- Ensure theme toggle icons (sun/moon) render as monochrome.
- Fix issue where fixed header would cover section titles after scroll navigation by using scroll-margin-top.
- Adjust IntersectionObserver threshold to correctly highlight 'Projects' and other sections in the navigation header when they are active in the viewport.